### PR TITLE
Increase timeout for connection re-test

### DIFF
--- a/common/pubnub-common.lua
+++ b/common/pubnub-common.lua
@@ -323,7 +323,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-channel-information/pubnub.lua
+++ b/corona/examples/example-channel-information/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-chat/pubnub.lua
+++ b/corona/examples/example-chat/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-dev-console/pubnub.lua
+++ b/corona/examples/example-dev-console/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-game-lobby-room/pubnub.lua
+++ b/corona/examples/example-game-lobby-room/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-hello-world/pubnub.lua
+++ b/corona/examples/example-hello-world/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-here_now/pubnub.lua
+++ b/corona/examples/example-here_now/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-history/pubnub.lua
+++ b/corona/examples/example-history/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-mathmania/pubnub.lua
+++ b/corona/examples/example-mathmania/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-multi-drum/pubnub.lua
+++ b/corona/examples/example-multi-drum/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-pub-sub-demo/pubnub.lua
+++ b/corona/examples/example-pub-sub-demo/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-publish/pubnub.lua
+++ b/corona/examples/example-publish/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-resubscribe/pubnub.lua
+++ b/corona/examples/example-resubscribe/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-subscribe/pubnub.lua
+++ b/corona/examples/example-subscribe/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-unsubscribe/pubnub.lua
+++ b/corona/examples/example-unsubscribe/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-uuid/pubnub.lua
+++ b/corona/examples/example-uuid/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/examples/example-where_now/pubnub.lua
+++ b/corona/examples/example-where_now/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/pubnub.lua
+++ b/corona/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/corona/tests/unit-tests/pubnub.lua
+++ b/corona/tests/unit-tests/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/moai/examples/example-subscribe/pubnub.lua
+++ b/moai/examples/example-subscribe/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/moai/pubnub.lua
+++ b/moai/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/pure/examples/example-subscribe/pubnub.lua
+++ b/pure/examples/example-subscribe/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end

--- a/pure/pubnub.lua
+++ b/pure/pubnub.lua
@@ -324,7 +324,7 @@ function pubnub.base(init)
                 change_origin()
 
                 -- Re-test Connection
-                self:set_timeout( SECOND, function()
+                self:set_timeout( 10*SECOND, function()
                     self:time(_test_connection);
                 end);
             end


### PR DESCRIPTION
Probably should make this user-configurable, but, for now, let it be
fixed, but longer, as there's not much to gain from it being so short.