### PR TITLE
Fix a form of "auto DoS attack"

### DIFF
--- a/common/pubnub-common.lua
+++ b/common/pubnub-common.lua
@@ -357,7 +357,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-channel-information/pubnub.lua
+++ b/corona/examples/example-channel-information/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-chat/pubnub.lua
+++ b/corona/examples/example-chat/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-dev-console/pubnub.lua
+++ b/corona/examples/example-dev-console/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-game-lobby-room/pubnub.lua
+++ b/corona/examples/example-game-lobby-room/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-hello-world/pubnub.lua
+++ b/corona/examples/example-hello-world/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-here_now/pubnub.lua
+++ b/corona/examples/example-here_now/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-history/pubnub.lua
+++ b/corona/examples/example-history/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-mathmania/pubnub.lua
+++ b/corona/examples/example-mathmania/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-multi-drum/pubnub.lua
+++ b/corona/examples/example-multi-drum/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-pub-sub-demo/pubnub.lua
+++ b/corona/examples/example-pub-sub-demo/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-publish/pubnub.lua
+++ b/corona/examples/example-publish/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-resubscribe/pubnub.lua
+++ b/corona/examples/example-resubscribe/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-subscribe/pubnub.lua
+++ b/corona/examples/example-subscribe/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-unsubscribe/pubnub.lua
+++ b/corona/examples/example-unsubscribe/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-uuid/pubnub.lua
+++ b/corona/examples/example-uuid/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/examples/example-where_now/pubnub.lua
+++ b/corona/examples/example-where_now/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/corona/pubnub.lua
+++ b/corona/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/moai/examples/example-subscribe/pubnub.lua
+++ b/moai/examples/example-subscribe/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/moai/pubnub.lua
+++ b/moai/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/pure/examples/example-subscribe/pubnub.lua
+++ b/pure/examples/example-subscribe/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end

--- a/pure/pubnub.lua
+++ b/pure/pubnub.lua
@@ -358,7 +358,6 @@ function pubnub.base(init)
         local function _poll_online()
             if stop_keepalive then return end
             self:time(function(success)
-                if not success then  _test_connection() end
                 self:set_timeout( KEEPALIVE, function() _poll_online() end)
             end)
         end


### PR DESCRIPTION
If a `poll_online()` would fail, that is, if a time transaction
(that we use for "polling") failed, we would call `_test_connection`
_and_ start a timer for (next) poll. Since `_test_connection` starts
another timer for another test with the time transaction, we would, if
connection to the Pubnub network is lost, keep piling up these time
transactions in a linear fashion. That is, each failed `poll_online()`
would start a new "thread" of time transactions, each of which would
only stop once the time transaction actually succeeds.

Basically, we don't need to react to a failed poll_online(), as it
might be a transient failure. In general, it would be nice to somehow
note that "currently, we don't seem to have a connection to Pubnub
network", but, the code doesn't support such a notion or notification.
We might add such a thing, but, it's out of scope of fixing this bug.